### PR TITLE
Require OT instead of using global from a script tag

### DIFF
--- a/Electron-Basic-Video-Chat/index.html
+++ b/Electron-Basic-Video-Chat/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <title>OpenTok Electron Application</title>
-    <script src="node_modules/@opentok/client/dist/js/opentok.min.js"></script>
   </head>
   <body>
     <div id="publisher"></div>

--- a/Electron-Basic-Video-Chat/openTok.js
+++ b/Electron-Basic-Video-Chat/openTok.js
@@ -1,3 +1,5 @@
+const OT = require('@opentok/client');
+
 // Set Credentials
 const apiKey = "";
 const sessionId = "";


### PR DESCRIPTION
Since we're already installed OT from npm then we might as well require it directly into our script rather than using a script tag.