### PR TITLE
Handlebars vulnerability fix

### DIFF
--- a/Angular-Basic-Video-Chat/package-lock.json
+++ b/Angular-Basic-Video-Chat/package-lock.json
@@ -4,39 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@angular-devkit/build-optimizer": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.32.tgz",
-      "integrity": "sha512-j09JdaFoRukEllfmH+TUJpe2ujUzTSj/szqYGHWVBilajwnNQh7f0A9v1R27mX+2di4x8tXuvaBgwvdEZBv32w==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "source-map": "0.5.7",
-        "typescript": "2.4.2",
-        "webpack-sources": "1.0.2"
-      }
-    },
-    "@angular-devkit/core": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.20.tgz",
-      "integrity": "sha512-lg5BvMxOfbVD//SOQvpq6TPIKTXYNMj0I9N/kfXbXkUGgiBGFLyFMf2fc+qNvDoa7lulKMPT8OJWS1YlGt93eg==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
-    },
-    "@angular-devkit/schematics": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.0.35.tgz",
-      "integrity": "sha512-+qGUWhmMpHqHkYKMk1yKQDjXb/vqXGkzbMiRs/u5rSnlrH+/TzkCO0UsM7/p9WPcModuDxkf5FItpw/AgdcPeQ==",
-      "dev": true,
-      "requires": {
-        "@angular-devkit/core": "0.0.20",
-        "@ngtools/json-schema": "1.1.0",
-        "minimist": "1.2.0",
-        "rxjs": "5.5.2"
-      }
-    },
     "@angular/animations": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.0.1.tgz",
@@ -46,16 +13,16 @@
       }
     },
     "@angular/cli": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.5.0.tgz",
-      "integrity": "sha512-nCXvqNCdi+8aOU2v6EABZsMg5bB7iM+wfaoWKnu9M5fOW2Rm+7/3Y1gDQKyFkgXCzXdy3J/xpfmwT0gjmjlvIA==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.5.5.tgz",
+      "integrity": "sha512-qAooJraZwT9o2W7yx6gY6fnc7PEMlGzu60ELZJfC51MnoYMPKiIEFYeWanCSNju1P7jfpeBXuwp1qEMZCX73Zw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/build-optimizer": "0.0.32",
-        "@angular-devkit/schematics": "0.0.35",
+        "@angular-devkit/build-optimizer": "0.0.34",
+        "@angular-devkit/schematics": "0.0.38",
         "@ngtools/json-schema": "1.1.0",
-        "@ngtools/webpack": "1.8.0",
-        "@schematics/angular": "0.1.2",
+        "@ngtools/webpack": "1.8.5",
+        "@schematics/angular": "0.1.8",
         "autoprefixer": "6.7.7",
         "chalk": "2.2.2",
         "circular-dependency-plugin": "3.0.0",
@@ -79,14 +46,15 @@
         "license-webpack-plugin": "1.1.1",
         "lodash": "4.17.4",
         "memory-fs": "0.4.1",
+        "minimatch": "3.0.4",
         "node-modules-path": "1.0.1",
         "node-sass": "4.6.0",
         "nopt": "4.0.1",
         "opn": "5.1.0",
         "portfinder": "1.0.13",
         "postcss-custom-properties": "6.2.0",
-        "postcss-loader": "1.3.3",
-        "postcss-url": "5.1.2",
+        "postcss-loader": "2.0.9",
+        "postcss-url": "7.3.0",
         "raw-loader": "0.5.1",
         "resolve": "1.5.0",
         "rxjs": "5.5.2",
@@ -108,6 +76,126 @@
         "webpack-sources": "1.0.2",
         "webpack-subresource-integrity": "1.0.1",
         "zone.js": "0.8.18"
+      },
+      "dependencies": {
+        "@angular-devkit/build-optimizer": {
+          "version": "0.0.34",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.34.tgz",
+          "integrity": "sha512-uSvyKtkDnfnBt6GGJ0m1nFI9IylKq6KoQil04GobhDCXFyin6Gbr50focx3jaizwDuh4v/x11fEUi5/cSUkKhA==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "source-map": "0.5.7",
+            "typescript": "2.6.2",
+            "webpack-sources": "1.0.2"
+          }
+        },
+        "@angular-devkit/core": {
+          "version": "0.0.22",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.22.tgz",
+          "integrity": "sha512-zxrNtTiv60liye/GGeRMnnGgLgAWoqlMTfPLMW0D1qJ4bbrPHtme010mpxS3QL4edcDtQseyXSFCnEkuo2MrRw==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "@angular-devkit/schematics": {
+          "version": "0.0.38",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.0.38.tgz",
+          "integrity": "sha512-vvyn7p/t4EKLSONGIw9jot9iMM3lEvdMDfnLkgubznIiIFxH9I+aYw9BBV2AmwE7OASHrCRpwFf7K2EqJ0f9+A==",
+          "dev": true,
+          "requires": {
+            "@angular-devkit/core": "0.0.22",
+            "@ngtools/json-schema": "1.1.0",
+            "minimist": "1.2.0",
+            "rxjs": "5.5.2"
+          }
+        },
+        "@ngtools/webpack": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.8.5.tgz",
+          "integrity": "sha512-caqEQuxypjZTQkO4wRykX4Mp7FCHUApTym5Yjr6VuM+zR4uVzjBceIaT/3a0X+p6iU4dmd6DpT2y96xki/YVSQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.2.2",
+            "enhanced-resolve": "3.4.1",
+            "loader-utils": "1.1.0",
+            "magic-string": "0.22.4",
+            "semver": "5.4.1",
+            "source-map": "0.5.7",
+            "tree-kill": "1.2.0"
+          }
+        },
+        "@schematics/angular": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.1.8.tgz",
+          "integrity": "sha512-88QrOoS0gQ6BdKulP01dTPmfPwLhvzb4jCcKkp0g8kvzTkIadlORmC9bQtucJI5huPU2bglVfmPgAk2ZwMSLDA==",
+          "dev": true,
+          "requires": {
+            "@angular-devkit/core": "0.0.22"
+          }
+        },
+        "postcss": {
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "4.5.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "postcss-loader": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.9.tgz",
+          "integrity": "sha512-sgoXPtmgVT3aBAhU47Kig8oPF+mbXl8Unjvtz1Qj1q2D2EvSVJW2mKJNzxv5y/LvA9xWwuvdysvhc7Zn80UWWw==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "postcss": "6.0.14",
+            "postcss-load-config": "1.2.0",
+            "schema-utils": "0.3.0"
+          }
+        },
+        "postcss-url": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-7.3.0.tgz",
+          "integrity": "sha512-VBP6uf6iL3AZra23nkPkOEkS/5azj1xf/toRrjfkolfFEgg9Gyzg9UhJZeIsz12EGKZTNVeGbPa2XtaZm/iZvg==",
+          "dev": true,
+          "requires": {
+            "mime": "1.4.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "postcss": "6.0.14",
+            "xxhashjs": "0.2.1"
+          }
+        },
+        "typescript": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+          "dev": true
+        }
       }
     },
     "@angular/common": {
@@ -198,34 +286,10 @@
       "integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI=",
       "dev": true
     },
-    "@ngtools/webpack": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.8.0.tgz",
-      "integrity": "sha512-QefALj8VUakHMI/Z/7RjyQR4UpAAfCXeoHqqD9+7Td3CZkuryyGQILqOSAg3d+cP+64iCwIb2jSKC+YAIy722Q==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.2.2",
-        "enhanced-resolve": "3.4.1",
-        "loader-utils": "1.1.0",
-        "magic-string": "0.22.4",
-        "semver": "5.4.1",
-        "source-map": "0.5.7",
-        "tree-kill": "1.2.0"
-      }
-    },
     "@opentok/client": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@opentok/client/-/client-2.12.1.tgz",
       "integrity": "sha1-QqL6CyZNJQ5CfwXxLOkDJ79RXqA="
-    },
-    "@schematics/angular": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.1.2.tgz",
-      "integrity": "sha512-q8VjdMic9Q/9A/csqNTvgtY9UnojMk+HgM/jE8zn+p0WW+PEk4KNRj5WCRAf+8yQ4yvAfDz1fKYAz2JDntmjVw==",
-      "dev": true,
-      "requires": {
-        "@angular-devkit/core": "0.0.20"
-      }
     },
     "@types/jasmine": {
       "version": "2.5.54",
@@ -1847,6 +1911,12 @@
         "source-map": "0.5.7"
       }
     },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2044,40 +2114,6 @@
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
         "randombytes": "2.0.5"
-      }
-    },
-    "directory-encoder": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/directory-encoder/-/directory-encoder-0.7.2.tgz",
-      "integrity": "sha1-WbTiqk8lQi9sY7UntGL14tDdLFg=",
-      "dev": true,
-      "requires": {
-        "fs-extra": "0.23.1",
-        "handlebars": "1.3.0",
-        "img-stats": "0.5.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.23.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
-          "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        }
       }
     },
     "dns-equal": {
@@ -4112,47 +4148,6 @@
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
     },
-    "handlebars": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
-      "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
-      "dev": true,
-      "requires": {
-        "optimist": "0.3.7",
-        "uglify-js": "2.3.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          }
-        }
-      }
-    },
     "har-schema": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
@@ -4580,15 +4575,6 @@
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
-    },
-    "img-stats": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/img-stats/-/img-stats-0.5.2.tgz",
-      "integrity": "sha1-wgNJbELy2esuWrgjL6dWurMsnis=",
-      "dev": true,
-      "requires": {
-        "xmldom": "0.1.27"
-      }
     },
     "import-local": {
       "version": "0.1.1",
@@ -6415,15 +6401,6 @@
         "is-wsl": "1.1.0"
       }
     },
-    "optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-      "dev": true,
-      "requires": {
-        "wordwrap": "0.0.3"
-      }
-    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -6982,18 +6959,6 @@
         "object-assign": "4.1.1"
       }
     },
-    "postcss-loader": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
-      "integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-load-config": "1.2.0"
-      }
-    },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
@@ -7330,21 +7295,6 @@
         "alphanum-sort": "1.0.2",
         "postcss": "5.2.18",
         "uniqs": "2.0.0"
-      }
-    },
-    "postcss-url": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-5.1.2.tgz",
-      "integrity": "sha1-mLMWW+jVkkccsMqt3iwNH4MvEz4=",
-      "dev": true,
-      "requires": {
-        "directory-encoder": "0.7.2",
-        "js-base64": "2.3.2",
-        "mime": "1.4.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "path-is-absolute": "1.0.1",
-        "postcss": "5.2.18"
       }
     },
     "postcss-value-parser": {
@@ -10121,12 +10071,6 @@
       "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
       "dev": true
     },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-      "dev": true
-    },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
@@ -10138,6 +10082,15 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
+    },
+    "xxhashjs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.1.tgz",
+      "integrity": "sha1-m76b6JYUKXbfo0wGGy0GjEPTDeA=",
+      "dev": true,
+      "requires": {
+        "cuint": "0.2.2"
+      }
     },
     "y18n": {
       "version": "3.2.1",

--- a/Angular-Basic-Video-Chat/package.json
+++ b/Angular-Basic-Video-Chat/package.json
@@ -28,7 +28,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.0",
+    "@angular/cli": "1.5.5",
     "@angular/compiler-cli": "^5.0.0",
     "@angular/language-service": "^5.0.0",
     "@types/jasmine": "~2.5.53",


### PR DESCRIPTION
Github warns us that handlebars < 4.0 has a vulnerability issue.
Updating the version of @angular/cli fixes this (by using an acceptable
version of handlebars as a dependency).