### PR TITLE
fixes #27 - add event listeners before connecting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: 8
 
-after_success: ./deploy.sh
+script: ./deploy.sh
 
 env:
   global:

--- a/Angular-Basic-Video-Chat/src/app/app.component.spec.ts
+++ b/Angular-Basic-Video-Chat/src/app/app.component.spec.ts
@@ -27,7 +27,7 @@ describe('AppComponent', () => {
     opentokService = fixture.debugElement.injector.get(OpentokService);
     spyOn(opentokService, 'getOT').and.returnValue(OT);
     opentokService.session = session;
-    spyOn(opentokService, 'connectSession').and.returnValue(Promise.resolve(session));
+    spyOn(opentokService, 'initSession').and.returnValue(Promise.resolve(session));
     app = fixture.debugElement.componentInstance;
     fixture.detectChanges();
   }));
@@ -41,9 +41,9 @@ describe('AppComponent', () => {
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('h1').textContent).toContain('Angular Basic Video Chat');
   });
-  it('should have called connectSession on the opentokService', () => {
+  it('should have called initSession on the opentokService', () => {
     expect(app.session).toBe(session);
-    expect(opentokService.connectSession).toHaveBeenCalled();
+    expect(opentokService.initSession).toHaveBeenCalled();
   });
   it('should populate the streams when we get a streamCreated', () => {
     expect(app.streams).toEqual([]);

--- a/Angular-Basic-Video-Chat/src/app/app.component.ts
+++ b/Angular-Basic-Video-Chat/src/app/app.component.ts
@@ -16,7 +16,7 @@ export class AppComponent implements OnInit {
   constructor(private opentokService: OpentokService) {}
 
   ngOnInit () {
-    this.opentokService.connectSession().then((session: OT.Session) => {
+    this.opentokService.initSession().then((session: OT.Session) => {
       this.session = session;
       this.session.on('streamCreated', (event) => {
         this.streams.push(event.stream);
@@ -27,7 +27,10 @@ export class AppComponent implements OnInit {
           this.streams.splice(idx, 1);
         }
       });
-    }).catch((err) => {
+    })
+    .then(() => this.opentokService.connect())
+    .catch((err) => {
+      console.error(err);
       alert('Unable to connect. Make sure you have updated the config.ts file with your OpenTok details.');
     });
   }

--- a/Angular-Basic-Video-Chat/src/app/opentok.service.spec.ts
+++ b/Angular-Basic-Video-Chat/src/app/opentok.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import * as OT from '@opentok/client';
 
 import { OpentokService } from './opentok.service';
+import config from '../config';
 
 
 describe('OpentokService', () => {
@@ -12,6 +13,9 @@ describe('OpentokService', () => {
   });
 
   describe('service', () => {
+    config.API_KEY = 'apiKey';
+    config.SESSION_ID = 'sessionId';
+    config.TOKEN = 'token';
     let service;
     beforeEach(inject([OpentokService], (s: OpentokService) => {
       service = s;
@@ -25,7 +29,7 @@ describe('OpentokService', () => {
       expect(service.getOT()).toEqual(OT);
     });
 
-    describe('connectSession()', () => {
+    describe('initSession()', () => {
       const OT = {
         initSession() {}
       };
@@ -37,10 +41,16 @@ describe('OpentokService', () => {
         spyOn(OT, 'initSession').and.returnValue(session);
       });
 
-      it('should call OT.initSession and connect', () => {
-        service.connectSession();
-        expect(OT.initSession).toHaveBeenCalledWith(jasmine.any(String), jasmine.any(String));
+      it('should call OT.initSession', () => {
+        service.initSession();
+        expect(OT.initSession).toHaveBeenCalledWith(config.API_KEY, config.SESSION_ID);
         expect(service.session).toEqual(session);
+      });
+
+      it('connect should call connect', () => {
+        service.initSession();
+        service.connect();
+        expect(service.session.connect).toHaveBeenCalledWith(config.TOKEN, jasmine.any(Function));
       });
     });
   });

--- a/Angular-Basic-Video-Chat/src/app/opentok.service.ts
+++ b/Angular-Basic-Video-Chat/src/app/opentok.service.ts
@@ -7,6 +7,7 @@ import config from '../config';
 export class OpentokService {
 
   session: OT.Session;
+  token: string;
 
   constructor() { }
 
@@ -14,20 +15,25 @@ export class OpentokService {
     return OT;
   }
 
-  connectSession() {
+  initSession() {
     if (config.API_KEY && config.TOKEN && config.SESSION_ID) {
-      return this.connect(config.API_KEY, config.SESSION_ID, config.TOKEN);
+      this.session = this.getOT().initSession(config.API_KEY, config.SESSION_ID);
+      this.token = config.TOKEN;
+      return Promise.resolve(this.session);
     } else {
       return fetch(config.SAMPLE_SERVER_BASE_URL + '/session')
         .then((data) => data.json())
-        .then((json) => this.connect(json.apiKey, json.sessionId, json.token));
+        .then((json) => {
+          this.session = this.getOT().initSession(json.apiKey, json.sessionId);
+          this.token = json.token;
+          return this.session;
+        });
     }
   }
 
-  connect(apiKey, sessionId, token) {
+  connect() {
     return new Promise((resolve, reject) => {
-      this.session = this.getOT().initSession(apiKey, sessionId);
-      this.session.connect(token, (err) => {
+      this.session.connect(this.token, (err) => {
         if (err) {
           reject(err);
         } else {

--- a/Angular-Basic-Video-Chat/src/app/publisher/publisher.component.spec.ts
+++ b/Angular-Basic-Video-Chat/src/app/publisher/publisher.component.spec.ts
@@ -29,6 +29,7 @@ describe('PublisherComponent', () => {
     fixture = TestBed.createComponent(PublisherComponent);
     component = fixture.componentInstance;
     component.session = jasmine.createSpyObj('OT.Session', ['on', 'publish']) as OT.Session;
+    component.session['isConnected'] = () => false;
     fixture.detectChanges();
   });
 

--- a/Angular-Basic-Video-Chat/src/app/publisher/publisher.component.ts
+++ b/Angular-Basic-Video-Chat/src/app/publisher/publisher.component.ts
@@ -26,7 +26,7 @@ export class PublisherComponent implements AfterViewInit {
       if (this.session['isConnected']()) {
         this.publish();
       }
-      this.session.on('sessionConnected', this.publish);
+      this.session.on('sessionConnected', () => this.publish());
     }
   }
 


### PR DESCRIPTION
It turns out that we were adding the event listeners for streamCreated after you are already connected to the session. This meant that new participants wouldn't see ones that are already there because they add the event listener after the event already fired.