### PR TITLE
Adding a sample app for publishing from a video file

### DIFF
--- a/Publish-Video/README.md
+++ b/Publish-Video/README.md
@@ -15,4 +15,4 @@ You can see a demo of this app running at [opentok.github.io/opentok-web-samples
 
 ## Known Limitations
 
-* The custom streaming API works on Chrome 53+. It currently does not work in Safari, Firefox, IE or Edge browsers.
+* This sample app works on Chrome 53+. [HTMLMediaElement.captureStream](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/captureStream) currently does not work in Safari, Firefox, IE or Edge browsers.

--- a/Publish-Video/README.md
+++ b/Publish-Video/README.md
@@ -1,0 +1,18 @@
+OpenTok.js Publish from a Video Element Sample
+===========================
+
+In this sample application we show you how to publish a Video file to an OpenTok Session.
+
+As of v2.13 of opentok.js you can set a custom audio source and video source for a publisher's stream when you call [`OT.initPublisher()`](https://tokbox.com/developer/sdks/js/reference/OT.html#initPublisher). The custom audio and video source are [`MediaStreamTrack`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack) objects. In this sample we obtain a `MediaStreamTrack` from a Video Element, using the [`captureStream()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/captureStream) method to get a `MediaStream` object, and then call `getVideoTracks()[0]` on that object to get the video `MediaStreamTrack` object and `getAudioTracks()[0]` to get the audio `MediaStreamTrack` object.
+
+## Demo
+
+You can see a demo of this app running at [opentok.github.io/opentok-web-samples/Publish-Video](https://opentok.github.io/opentok-web-samples/Publish-Video)
+
+## Running the App
+
+* Simply open [index.html](index.html) in your browser.
+
+## Known Limitations
+
+* The custom streaming API works on Chrome 53+. It currently does not work in Safari, Firefox, IE or Edge browsers.

--- a/Publish-Video/index.html
+++ b/Publish-Video/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Publish from a Video Element</title>
+
+    <script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
+    <style media="screen">
+      html, body {
+        font-family: Helvetica, Arial, sans-serif;
+        background: #fff;
+        margin: 0px;
+      }
+      div.wrapper label {
+        display: block;
+        width: 100%;
+        text-align: center;
+        font-weight: bold;
+        font-size: 20px;
+      }
+      div.wrapper {
+        width: 320px;
+        float: left;
+        margin: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <label>Video</label>
+      <video id="video" src="video/BigBuckBunny_320x180.mp4" width="320" height="240" controls></video>
+    </div>
+    <div class="wrapper">
+      <label>Publisher</label>
+      <div id="publisher"></div>
+    </div>
+
+    <!-- Credit to Tim Holman for the Github corners http://tholman.com/github-corners/ -->
+    <a href="https://github.com/opentok/opentok-web-samples/tree/master/Publish-Video" class="github-corner" aria-label="View source on Github"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+
+    <script src="js/app.js" charset="utf-8"></script>
+  </body>
+</html>

--- a/Publish-Video/js/app.js
+++ b/Publish-Video/js/app.js
@@ -1,0 +1,37 @@
+/* global OT */
+
+(function closure() {
+  const video = document.querySelector('#video');
+  if (!video.captureStream) {
+    alert('This browser does not support VideoElement.captureStream(). You must use Google Chrome.');
+    return;
+  }
+  const stream = video.captureStream();
+  let publisher;
+  const publish = () => {
+    const videoTracks = stream.getVideoTracks();
+    const audioTracks = stream.getAudioTracks();
+    if (!publisher && videoTracks.length > 0 && audioTracks.length > 0) {
+      stream.removeEventListener('addtrack', publish);
+      publisher = OT.initPublisher('publisher', {
+        videoSource: videoTracks[0],
+        audioSource: audioTracks[0],
+        fitMode: 'contain',
+        width: 320,
+        height: 240
+      }, (err) => {
+        if (err) {
+          video.pause();
+          alert(err.message);
+        } else {
+          video.play();
+        }
+      });
+      publisher.on('destroyed', () => {
+        video.pause();
+      });
+    }
+  };
+  stream.addEventListener('addtrack', publish);
+  publish();
+})();

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The code for this sample is found the following subdirectories:
 
 * Publish-Canvas ([demo](https://opentok.github.io/opentok-web-samples/Publish-Canvas/)) ([source](https://github.com/opentok/opentok-web-samples/tree/master/Publish-Canvas)) -- In this sample application we show you how to publish a custom stream from a Canvas tag.
 
+* Publish-Video ([demo](https://opentok.github.io/opentok-web-samples/Publish-Video/)) ([source](https://github.com/opentok/opentok-web-samples/tree/master/Publish-Video)) -- In this sample application we show you how to publish a video file to an OpenTok Session.
+
 * React-Basic-Video-Chat ([demo](https://opentok.github.io/opentok-web-samples/React-Basic-Video-Chat/)) ([source](https://github.com/opentok/opentok-web-samples/tree/master/React-Basic-Video-Chat)) -- This sample shows you how to connect to an OpenTok session, publish a stream, and
   subscribe to a stream using [React](https://reactjs.org/). You can also toggle the video by clicking on the Video button.
 

--- a/compile.sh
+++ b/compile.sh
@@ -20,6 +20,9 @@ sed -i -- 's/http:\/\/YOUR-SERVER-URL/https:\/\/opentok-web-samples-backend.hero
 # Copy Publish-Canvas
 cp -r Publish-Canvas out/
 
+# Copy Publish-Canvas
+cp -r Publish-Video out/
+
 # Copy Stream Filter
 cp -r Stream-Filter out/
 sed -i -- 's/http:\/\/YOUR-SERVER-URL/https:\/\/opentok-web-samples-backend.herokuapp.com/g' out/Stream-Filter/js/config.js

--- a/index.html
+++ b/index.html
@@ -51,6 +51,8 @@
 
         <li><a href="Publish-Canvas/">Publish-Canvas</a> - In this sample application we show you how to publish a custom stream from a Canvas tag.</li>
 
+        <li><a href="Publish-Video/">Publish-Video</a> - In this sample application we show you how to publish a video file to an OpenTok Session.</li>
+
         <li><a href="React-Basic-Video-Chat/">React-Basic-Video-Chat</a> - This sample shows you how to connect to an OpenTok session, publish a stream, and subscribe to a stream using React. You can also toggle the video by clicking on the Video button.</li>
 
         <li><a href="Signaling/">Signaling</a> - This sample shows you how to use the OpenTok signaling API to implement text chat.</li>


### PR DESCRIPTION
In this sample application we show you how to publish a Video file to an OpenTok Session.

As of v2.13 of opentok.js you can set a custom audio source and video source for a publisher's stream when you call [`OT.initPublisher()`](https://tokbox.com/developer/sdks/js/reference/OT.html#initPublisher). The custom audio and video source are [`MediaStreamTrack`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack) objects. In this sample we obtain a `MediaStreamTrack` from a Video Element, using the [`captureStream()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/captureStream) method to get a `MediaStream` object, and then call `getVideoTracks()[0]` on that object to get the video `MediaStreamTrack` object and `getAudioTracks()[0]` to get the audio `MediaStreamTrack` object.

## Running the App
* Simply open [index.html](index.html) in your browser.

## Known Limitations
* This sample app works on Chrome 53+. [HTMLMediaElement.captureStream](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/captureStream) currently does not work in Safari, Firefox, IE or Edge browsers.