### PR TITLE
Fix android cycleVideo issue

### DIFF
--- a/Publish-Devices/js/app.js
+++ b/Publish-Devices/js/app.js
@@ -22,13 +22,17 @@
         }
         return innerHTML;
       }, '');
+      publishBtn.disabled = false;
     });
   }
-
+  publishBtn.disabled = true;
   // We request access to Microphones and Cameras so we can get the labels
-  OT.getUserMedia().then(() => {
+  OT.getUserMedia().then((stream) => {
     populateDeviceSources(audioSelector, 'audioInput');
     populateDeviceSources(videoSelector, 'videoInput');
+    // Stop the tracks so that we stop using this camera and microphone
+    // If you don't do this then cycleVideo does not work on some Android devices
+    stream.getTracks().forEach(track => track.stop());
   });
 
   // Start publishing when you click the publish button


### PR DESCRIPTION
Fixed a bug where if you call cycleVideo on some android devices you get an error saying the camera is in use. It turns out we need to stop the tracks on the stream we get when we call OT.getUserMedia.

This also fixes an issue where if you click publish too soon you get an error. It disables the publish button until you can click it.