### PR TITLE
Remove tests for Internet Explorer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       env: BROWSER=safari BVER=stable
-    - os: linux
-      env: BROWSER=ie BVER=11 SAUCELABS=true
 
 env:
   global:

--- a/Archiving/test/test-chrome-firefox-safari-ie.js
+++ b/Archiving/test/test-chrome-firefox-safari-ie.js
@@ -51,13 +51,11 @@ describe('Archiving Sample Test', () => {
       const viewButton = $('#buttons #view');
       viewButton.waitForVisible(2000);
       // Wait for us go to the archive view URL
-      if (browser.desiredCapabilities.browserName !== 'internet explorer') {
-        viewButton.click();
-        browser.waitUntil(() => {
-          let pageUrl = browser.getUrl();
-          return pageUrl.match('^https:\/\/.+\/archive\/.+\/view$', 'ga');
-        }, 5000);
-      }
+      viewButton.click();
+      browser.waitUntil(() => {
+        let pageUrl = browser.getUrl();
+        return pageUrl.match('^https:\/\/.+\/archive\/.+\/view$', 'ga');
+      }, 5000);
     });
   });
 });

--- a/compile.sh
+++ b/compile.sh
@@ -67,10 +67,5 @@ if [ "$BROWSER" = "safari" ]; then
 else
   npm start &
 fi
-if [ "$BROWSER" = "ie" ]; then
-  ./node_modules/opentok-test-scripts/plugin-installer/packageSauceLabsInstaller.sh
-  mkdir -p out/plugin-installer
-  mv ./node_modules/opentok-test-scripts/plugin-installer/SauceLabsInstaller.exe out/plugin-installer
-fi
 npm test
 if [ "$BROWSER" = "ie" ]; then rm -r out/plugin-installer; fi

--- a/startSelenium.sh
+++ b/startSelenium.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Chrome uses the standalone ChromeDriver and IE runs on Sauce Labs
-if [[ "$BROWSER" != "chrome" && "$BROWSER" != "ie" ]]; then
+# Chrome uses the standalone ChromeDriver
+if [[ "$BROWSER" != "chrome" ]]; then
   if [ ! -f selenium-server-standalone-3.5.3.jar ]; then
     curl -O http://selenium-release.storage.googleapis.com/3.5/selenium-server-standalone-3.5.3.jar
   fi

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -270,23 +270,6 @@ case 'safari':
   });
   config.baseUrl = 'http://127.0.0.1';
   break;
-case 'ie':
-  config.services.push('sauce');
-  config.user = process.env.SAUCE_USERNAME;
-  config.key = process.env.SAUCE_ACCESS_KEY;
-  config.sauceConnect = false;
-  config.sauceConnectOpts = {
-    tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
-  };
-  config.capabilities.push({
-    browserName: 'internet explorer',
-    version: 11,
-    platform: 'Windows 8.1',
-    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
-    prerun: 'http://localhost:8080/plugin-installer/SauceLabsInstaller.exe',
-    background: false
-  });
-  break;
 case 'chrome':
 default:
   // Default to chrome


### PR DESCRIPTION
The version of SauceLabsInstaller.exe included opentok-test-scripts failed in Travis tests. Also note that OpenTok.js version 2.16 is the last version to support the OpenTok Plugin for Internet Explorer.